### PR TITLE
Add weather forecast endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Iceland API Proxy
+
+This repository contains simple API route handlers for fetching data from
+[apis.is](http://apis.is). These handlers can be deployed as serverless
+functions (for example in a Next.js `pages/api` directory) or used in a
+custom server setup.
+
+## Available handlers
+
+- **concerts.js** – Fetches concert information.
+- **weather.js** – Fetches the English weather forecast.
+
+Each handler forwards the response from the external API and enables CORS by
+setting `Access-Control-Allow-Origin` to `*`.

--- a/weather.js
+++ b/weather.js
@@ -1,0 +1,11 @@
+export default async function handler(req, res) {
+  try {
+    const response = await fetch('http://apis.is/weather/forecasts/en');
+    const data = await response.json();
+    // Allow any domain to access this endpoint (for browser CORS)
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.status(200).json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch weather forecast' });
+  }
+}


### PR DESCRIPTION
## Summary
- create an API handler for weather forecast data
- document available handlers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68482d45a2a4832e8fb3054b5b9d9f88